### PR TITLE
Fix refineDiag_atmos.csh's exit status

### DIFF
--- a/refineDiag_atmos.csh
+++ b/refineDiag_atmos.csh
@@ -10,6 +10,8 @@ set refineDiagDir = $2  # OUTPUT DIRECTORY
 
 set refineAtmosErrors = 0
 
+cd $source_dir
+
 foreach INFILE (`/bin/ls *.{atmos,aerosol}*cmip*.nc`)
   # replace cmip in output filename by refined
   set OUTFILE = `echo $INFILE | sed -e 's/_cmip/_refined/'`
@@ -23,3 +25,5 @@ foreach INFILE (`/bin/ls *.atmos_daily*cmip*.nc`)
   $source_dir/refine_Atmos_redux_daily_to_monthly.py $INFILE -o $refineDiagDir/$OUTFILE -v
   if ($?) @ refineAtmosErrors++
 end
+
+exit $refineAtmosErrors


### PR DESCRIPTION
Accumulate the errors in a variable, and then return that variable.

Also change directory to the input directory (though when FRE calls it the input directory is the current working directory).